### PR TITLE
Serv client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,10 +36,19 @@ include_directories(
 file(GLOB MY_L_SOURCES *.lcpp)
 add_custom_command(OUTPUT Generated COMMAND "mono" "${PROJECT_SOURCE_DIR}/../RTCOP/Tool/LayerCompiler.exe" "${MY_L_SOURCES}" "-r" "${PROJECT_SOURCE_DIR}" "-i" "${PROJECT_SOURCE_DIR}" "-t" "linux64" "-e" "gcc" "-o" "${PROJECT_SOURCE_DIR}/Generated")
 link_directories(../RTCOP/Library/Linux/x64)
-file(GLOB MY_SOURCES *.cpp Generated/*.cpp gnc/*.cpp PLAM/*.cpp)
-add_executable(${PROJECT_NAME}_node Generated ${MY_SOURCES})
+file(GLOB MAIN main.cpp Generated/*.cpp gnc/*.cpp PLAM/*.cpp)
+file(GLOB GROUND ground_node.cpp Generated/*.cpp gnc/*.cpp PLAM/*.cpp)
+add_executable(${PROJECT_NAME}_node Generated ${MAIN})
+add_executable(ground_node Generated ${GROUND})
+
 target_link_libraries(${PROJECT_NAME}_node
   RTCOP
   ${catkin_LIBRARIES}
 )
+
+target_link_libraries(ground_node
+  RTCOP
+  ${catkin_LIBRARIES}
+)
+
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,17 @@ find_package(catkin REQUIRED COMPONENTS
   mavros
   roscpp
   std_msgs
+  message_generation
+)
+
+add_service_files(
+  FILES
+  AddTwoInts.srv
+)
+
+generate_messages(
+  DEPENDENCIES
+  std_msgs  # Or other packages containing msgs
 )
 
 catkin_package(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0.2)
-project(Ardupilot-RTCOP-ROS)
+project(ardupilot_rtcop_ros)
 
 set(CMAKE_C_FLAGS "-no-pie -std=c++11 -pthread")
 set(CMAKE_CXX_FLAGS "-no-pie -std=c++1z -pthread")
@@ -10,12 +10,14 @@ find_package(catkin REQUIRED COMPONENTS
   mavros
   roscpp
   std_msgs
+  genmsg
   message_generation
 )
 
 add_service_files(
+  DIRECTORY srv
   FILES
-  AddTwoInts.srv
+  activation_msg.srv
 )
 
 generate_messages(
@@ -28,6 +30,7 @@ catkin_package(
 #  LIBRARIES Ardupilot-RTCOP-ROS
 #  CATKIN_DEPENDS other_catkin_pkg
 #  DEPENDS system_lib
+CATKIN_DEPENDS message_runtime
 )
 
 ###########
@@ -42,6 +45,7 @@ include_directories(
     ./PLAM
     .
     ${catkin_INCLUDE_DIRS}
+    
 )
 
 file(GLOB MY_L_SOURCES *.lcpp)
@@ -49,8 +53,12 @@ add_custom_command(OUTPUT Generated COMMAND "mono" "${PROJECT_SOURCE_DIR}/../RTC
 link_directories(../RTCOP/Library/Linux/x64)
 file(GLOB MAIN main.cpp Generated/*.cpp gnc/*.cpp PLAM/*.cpp)
 file(GLOB GROUND ground_node.cpp Generated/*.cpp gnc/*.cpp PLAM/*.cpp)
+file(GLOB FLIGHT flight_node.cpp Generated/*.cpp gnc/*.cpp PLAM/*.cpp)
+file(GLOB NOSIGNAL nosignal_node.cpp Generated/*.cpp gnc/*.cpp PLAM/*.cpp)
 add_executable(${PROJECT_NAME}_node Generated ${MAIN})
 add_executable(ground_node Generated ${GROUND})
+add_executable(flight_node Generated ${FLIGHT})
+add_executable(nosignal_node Generated ${NOSIGNAL})
 
 target_link_libraries(${PROJECT_NAME}_node
   RTCOP
@@ -58,6 +66,16 @@ target_link_libraries(${PROJECT_NAME}_node
 )
 
 target_link_libraries(ground_node
+  RTCOP
+  ${catkin_LIBRARIES}
+)
+
+target_link_libraries(flight_node
+  RTCOP
+  ${catkin_LIBRARIES}
+)
+
+target_link_libraries(nosignal_node
   RTCOP
   ${catkin_LIBRARIES}
 )

--- a/README.md
+++ b/README.md
@@ -51,20 +51,26 @@ source ~/.bashrc
 
 ## 実行
 
-ターミナル４つ開く（A，B，C，Dと略称）
-順番により
 ```
-roslaunch iq_sim runway.launch　
-cd ~/ardupilot/ArduCopter/ && sim_vehicle.py -v ArduCopter -f gazebo-iris --cons
-roslaunch iq_sim apm.launch
-rosrun Ardupilot-RTCOP-ROS Ardupilot-RTCOP-ROS_node
+cd ~/catkin_ws/src/ardupilot_rtcop_ros/shell/
+sh node_group_start.sh
+```
+
+十秒ぐらいを待ちして
+
+```
+rosrun ardupilot_rtcop_ros ardupilot_rtcop_ros_node
 ```
 
 を実行する
 
-Ｄを実行したらＢに戻し、"mode guided"を実行
+元のターミナルで３つのタブが自動的に開かれる（以下で左側からA,B,Cと略称する）
 
-すべてのINFOをＤで表示する。
+Aタブでメインノードを実行する
+
+レイヤコントロールノードにおけるリクエスト情報がＢタブに見られる
+
+メインノードの動かせるためＣタブでmode guidedを入力してください。
 
 ## チュートリアル
 

--- a/flight_node.cpp
+++ b/flight_node.cpp
@@ -22,7 +22,7 @@ bool msg_return(ardupilot_rtcop_ros::activation_msg::Request &req,
 int main(int argc, char **argv){
     ros::init(argc,argv,"flight_node");
     ros::NodeHandle flight_node;
-    ros::ServiceServer service = flight_node.advertiseService("activation2", msg_return);
+    ros::ServiceServer service = flight_node.advertiseService("flight_activation", msg_return);
     ros::spin();
     return 0;
 }

--- a/flight_node.cpp
+++ b/flight_node.cpp
@@ -13,16 +13,16 @@ bool msg_return(ardupilot_rtcop_ros::activation_msg::Request &req,
          ardupilot_rtcop_ros::activation_msg::Response &res)
 {
     // テスト版として応答メッセージに"_ok"を追加だけ
-    if(strcmp(req.activation.c_str(),"ground_activate") == 0 || strcmp(req.activation.c_str(),"ground_deactivate") == 0)
+    if(strcmp(req.activation.c_str(),"flight_activate") == 0 || strcmp(req.activation.c_str(),"flight_deactivate") == 0)
         res.activation_return = req.activation + "_ok";
     ROS_INFO("request: %s", res.activation_return.c_str()); 
     return true;
 }
 
 int main(int argc, char **argv){
-    ros::init(argc,argv,"ground_node");
-    ros::NodeHandle ground_node;
-    ros::ServiceServer service = ground_node.advertiseService("activation", msg_return);
+    ros::init(argc,argv,"flight_node");
+    ros::NodeHandle flight_node;
+    ros::ServiceServer service = flight_node.advertiseService("activation2", msg_return);
     ros::spin();
     return 0;
 }

--- a/ground_node.cpp
+++ b/ground_node.cpp
@@ -1,0 +1,30 @@
+#include <ros/ros.h>
+#include "Generated/API.h"
+#include "Generated/BaseLayer.h"
+#include "gnc_functions.h"
+#include "ActiveController.h"
+#include "string.h"
+
+using namespace gnc;
+using namespace PLAM;
+
+void chatterCallback(const std_msgs::String::ConstPtr& msg){
+    ROS_INFO("I heard:[%s]", msg->data.c_str());
+    string ground_activate = "ground_activate";
+    ROS_INFO("%d", strcmp(msg->data.c_str(),"ground_activate"));
+    if(strcmp(msg->data.c_str(),ground_activate.c_str()) == 0){
+        //active_normal(RTCOP::Generated::LayerID::Flight);
+        RTCOP::activate(RTCOP::Generated::LayerID::Ground);
+    }else if(strcmp(msg->data.c_str(),"ground_deactivate") == 0){
+        deactive_normal(RTCOP::Generated::LayerID::Ground);
+    }
+}
+
+int main(int argc, char **argv){
+    RTCOP::Framework::Instance->Initialize();
+    ros::init(argc,argv,"ground_node");
+    ros::NodeHandle ground_node;
+    ros::Subscriber sub = ground_node.subscribe("chatter", 1000, chatterCallback);
+    ros::spin();
+    return 0;
+}

--- a/ground_node.cpp
+++ b/ground_node.cpp
@@ -22,7 +22,7 @@ bool msg_return(ardupilot_rtcop_ros::activation_msg::Request &req,
 int main(int argc, char **argv){
     ros::init(argc,argv,"ground_node");
     ros::NodeHandle ground_node;
-    ros::ServiceServer service = ground_node.advertiseService("activation", msg_return);
+    ros::ServiceServer service = ground_node.advertiseService("ground_activation", msg_return);
     ros::spin();
     return 0;
 }

--- a/ground_node.cpp
+++ b/ground_node.cpp
@@ -8,23 +8,27 @@
 using namespace gnc;
 using namespace PLAM;
 
+ros::Publisher pub;
+ros::Subscriber sub;
+
 void chatterCallback(const std_msgs::String::ConstPtr& msg){
     ROS_INFO("I heard:[%s]", msg->data.c_str());
-    string ground_activate = "ground_activate";
-    ROS_INFO("%d", strcmp(msg->data.c_str(),"ground_activate"));
-    if(strcmp(msg->data.c_str(),ground_activate.c_str()) == 0){
-        //active_normal(RTCOP::Generated::LayerID::Flight);
-        RTCOP::activate(RTCOP::Generated::LayerID::Ground);
-    }else if(strcmp(msg->data.c_str(),"ground_deactivate") == 0){
-        deactive_normal(RTCOP::Generated::LayerID::Ground);
-    }
+    std_msgs::String return_msg;
+    std::stringstream ss;
+    ss<< msg->data.c_str() << "_ok";
+    return_msg.data = ss.str();
+
+    pub.publish(return_msg);
+    ros::spinOnce();
+    ROS_INFO("%s", return_msg.data.c_str());
 }
 
 int main(int argc, char **argv){
     RTCOP::Framework::Instance->Initialize();
     ros::init(argc,argv,"ground_node");
     ros::NodeHandle ground_node;
-    ros::Subscriber sub = ground_node.subscribe("chatter", 1000, chatterCallback);
+    pub = ground_node.advertise<std_msgs::String>("chatter2",1000);
+    sub = ground_node.subscribe("chatter", 1000, chatterCallback);
     ros::spin();
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -6,6 +6,7 @@
 
 using namespace gnc;
 using namespace PLAM;
+
 int main(int argc, char **argv) {
 	//------------ROS・Ardupilotなどの初期化------------
 	// initialize ros
@@ -15,7 +16,9 @@ int main(int argc, char **argv) {
 	
 	init_publisher_subscriber(gnc_node);
 
-    // wait for FCU connection
+	ros::Publisher chatter_pub = gnc_node.advertise<std_msgs::String>("chatter",1000);
+
+	// wait for FCU connection
 	wait4connect();
 
 	//wait for used to switch to mode GUIDED
@@ -24,54 +27,68 @@ int main(int argc, char **argv) {
 	//create local reference frame 
 	initialize_local_frame();            
 	//------------ROS・Ardupilotなどの初期化　完了------------
-  	
+	int count = 0;
+  	// while (ros::ok())
+  	// {
+    // 	/* code */
+    // 	std_msgs::String msg;
+
+    // 	std::stringstream ss;
+
+    // 	ss<< "hello world" << count;
+
+    // 	msg.data = ss.str();
+
+    // 	ROS_INFO("%s", msg.data.c_str());
+
+    // 	chatter_pub.publish(msg);
+
+    // 	ros::spinOnce();
+
+    // 	rate.sleep();
+    // 	++count;
+  	// }
+
 	// initialize rtcop
   	RTCOP::Framework::Instance->Initialize();
 
 	// instantiate class Hello
 	baselayer::Hello* hello = RTCOP::copnew<baselayer::Hello>();
 	hello->Print();
-  	rate.sleep();                   
-	// Ground Mode 起動
-	active_normal(RTCOP::Generated::LayerID::Ground);
+  	rate.sleep(); 
+	
+	std_msgs::String msg;
+
+	std::stringstream ss;
+	
+	//ss<<"hello world!";
+	msg.data = "hello world!";
+    ROS_INFO("%s", msg.data.c_str());
+    chatter_pub.publish(msg);
+    ros::spinOnce();
+    rate.sleep();
+
+	sleep(5);
 	hello->Print();
-  	rate.sleep();                   
-	sleep(3);
+	//ss.clear();
+	//ss<<"ground_activate";
+	msg.data = "ground_activate";
+    ROS_INFO("%s", msg.data.c_str());
+    chatter_pub.publish(msg);
+    ros::spinOnce();
+    rate.sleep();
 
-	// Ground Mode 解除（PLAMにおける正常系deactivate関数をちょっとBUGが発見したため、もうちょっと修正します）
-	RTCOP::deactivate(RTCOP::Generated::LayerID::Ground);
-	// Flight Mode　起動
-	active_normal(RTCOP::Generated::LayerID::Flight);
-	hello->Print(); //Flight modeアクティベーションが完了していないのでbase layerのhelloが表示される
-	sleep(25);
+	sleep(5);
+	hello->Print();
+	//ss.clear();
+	//ss<<"ground_deactivate";
+	msg.data = "ground_deactivate";
+    ROS_INFO("%s", msg.data.c_str());
+    chatter_pub.publish(msg);
+    ros::spinOnce();
+    rate.sleep();
+	
+	sleep(5);
+	hello->Print();
 
-	//信号途絶が発生
-	ROS_INFO_STREAM("[RTCOP]:No signal found!");
-
-	//Nosignal Mode 起動
-	active_suspend_until_deactive(RTCOP::Generated::LayerID::Nosignal);
-
-	int time_counter = 0;
-	while (ros::ok())//一秒ごとでprint関数を実行する
-	{
-		hello->Print();//Nosignal modeアクティベーションが完了。Nosignal modeのhelloが表示される
-		sleep(1);
-		time_counter++;
-		if (time_counter >= 10)
-		{
-			break;
-		}
-		
-	}
-
-	//再接続成功、Nosignal Mode 解除
-	deactive_suspend(RTCOP::Generated::LayerID::Nosignal);                   
-	hello->Print(); //Flight modeアクティベーションが完了していないのでbase layerのhelloが表示される
-	sleep(70);
-	hello->Print(); //Flight modeアクティベーションが完了。Flight modeのhelloが表示される
-	// Helloのdelete
-	delete hello;
-
-	// RTCOPの終了処理
-	RTCOP::Framework::Instance->Finalize();
 }

--- a/nosignal_node.cpp
+++ b/nosignal_node.cpp
@@ -22,7 +22,7 @@ bool msg_return(ardupilot_rtcop_ros::activation_msg::Request &req,
 int main(int argc, char **argv){
     ros::init(argc,argv,"nosignal_node");
     ros::NodeHandle nosignal_node;
-    ros::ServiceServer service = nosignal_node.advertiseService("activation3", msg_return);
+    ros::ServiceServer service = nosignal_node.advertiseService("nosignal_activation", msg_return);
     ros::spin();
     return 0;
 }

--- a/nosignal_node.cpp
+++ b/nosignal_node.cpp
@@ -13,16 +13,16 @@ bool msg_return(ardupilot_rtcop_ros::activation_msg::Request &req,
          ardupilot_rtcop_ros::activation_msg::Response &res)
 {
     // テスト版として応答メッセージに"_ok"を追加だけ
-    if(strcmp(req.activation.c_str(),"ground_activate") == 0 || strcmp(req.activation.c_str(),"ground_deactivate") == 0)
+    if(strcmp(req.activation.c_str(),"nosignal_activate") == 0 || strcmp(req.activation.c_str(),"nosignal_deactivate") == 0)
         res.activation_return = req.activation + "_ok";
     ROS_INFO("request: %s", res.activation_return.c_str()); 
     return true;
 }
 
 int main(int argc, char **argv){
-    ros::init(argc,argv,"ground_node");
-    ros::NodeHandle ground_node;
-    ros::ServiceServer service = ground_node.advertiseService("activation", msg_return);
+    ros::init(argc,argv,"nosignal_node");
+    ros::NodeHandle nosignal_node;
+    ros::ServiceServer service = nosignal_node.advertiseService("activation3", msg_return);
     ros::spin();
     return 0;
 }

--- a/package.xml
+++ b/package.xml
@@ -55,6 +55,8 @@
   <build_export_depend>std_msgs</build_export_depend>
   <exec_depend>mavros</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <build_depend>message_generation</build_depend>
+  <exec_depend>message_runtime</exec_depend>
   <!-- <depend>rtcop</depend> -->
 
 

--- a/package.xml
+++ b/package.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package format="2">
-  <name>Ardupilot-RTCOP-ROS</name>
+  <name>ardupilot_rtcop_ros</name>
   <version>0.0.0</version>
-  <description>The Ardupilot-RTCOP-ROS package</description>
+  <description>The ardupilot_rtcop_ros package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->

--- a/shell/node_group.launch
+++ b/shell/node_group.launch
@@ -1,0 +1,8 @@
+<launch>
+    <node name="ground_node" pkg="ardupilot_rtcop_ros"
+          type="ground_node" output="screen"/>
+    <node name="flight_node" pkg="ardupilot_rtcop_ros"
+          type="flight_node" output="screen"/>
+    <node name="nosignal_node" pkg="ardupilot_rtcop_ros"
+          type="nosignal_node" output="screen"/>
+</launch>

--- a/shell/node_group_start.sh
+++ b/shell/node_group_start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+gnome-terminal --window "plugin" -- ./plugin.sh;
+
+sleep 10;
+
+gnome-terminal --tab "node_group" -- roslaunch ardupilot_rtcop_ros node_group.launch
+
+sleep 1;
+
+gnome-terminal --tab "sitl start" -- ./startsitl.sh;

--- a/shell/plugin.sh
+++ b/shell/plugin.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+gnome-terminal --tab "world start" -- roslaunch iq_sim runway.launch;
+
+sleep 10;
+
+gnome-terminal --tab "sitl start" -- roslaunch iq_sim apm.launch;
+
+
+

--- a/shell/startsitl.sh
+++ b/shell/startsitl.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cd ~/ardupilot/ArduCopter/ && sim_vehicle.py -v ArduCopter -f gazebo-iris --console

--- a/srv/activation_msg
+++ b/srv/activation_msg
@@ -1,3 +1,0 @@
-string activation
----
-string activation_return

--- a/srv/activation_msg
+++ b/srv/activation_msg
@@ -1,0 +1,3 @@
+string activation
+---
+string activation_return

--- a/srv/activation_msg.srv
+++ b/srv/activation_msg.srv
@@ -1,0 +1,3 @@
+string activation
+---
+string activation_return


### PR DESCRIPTION
server-clientの方法を用いて横取り可能なact/deactを実装しました。
リヤルタイムで応答できるため、pub/subにより性能がかなり向上しました。
ただしレイヤー毎でノード・サーバーを作るべきたので、メインノードでノード毎に対してclientを作らないと行けません。したがって、コードはややこしくなってしまいました。

ちなみにパッケージ名をardupilot_rtcop_rosに変更してください。